### PR TITLE
카드사 앱 팝업 무한 호출 현상 수정

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.0.0")),
-        .package(name: "RxBusForPort", url: "https://github.com/iamport/RxBus-Swift", .upToNextMinor(from: "1.3.0")),
+        .package(name: "RxBusForPort", url: "https://github.com/iamport/RxBus-Swift", .upToNextMinor(from: "1.3.6-alpha.1")),
         .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.4.0")),
         .package(url: "https://github.com/devxoul/Then.git", .upToNextMajor(from: "2.7.0")),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.50.4")

--- a/Sources/iamport-ios/Classes/Domain/StrategyRepository.swift
+++ b/Sources/iamport-ios/Classes/Domain/StrategyRepository.swift
@@ -12,15 +12,25 @@ class StrategyRepository {
     enum PaymentKind {
         case CHAI, NICE, WEB, INICIS
     }
+    init(eventBus: EventBus) {
+        self.eventBus = eventBus
+        judgeStrategy = JudgeStrategy(eventBus: self.eventBus)
+        chaiStrategy = ChaiStrategy(eventBus: self.eventBus)
+        webViewStrategy = WebViewStrategy(eventBus: self.eventBus)
+        niceTransWebViewStrategy = NiceTransWebViewStrategy(eventBus: self.eventBus)
+        inicisTransWebViewStrategy = InicisTransWebViewStrategy(eventBus: self.eventBus)
+        certificationWebViewStrategy = CertificationWebViewStrategy(eventBus: self.eventBus)
+    }
+    let eventBus: EventBus
 
-    let judgeStrategy = JudgeStrategy() // 결제 판별
-    let chaiStrategy = ChaiStrategy() // 결제 중 BG 폴링하는 차이 전략
+    let judgeStrategy: JudgeStrategy  // 결제 판별
+    let chaiStrategy: ChaiStrategy // 결제 중 BG 폴링하는 차이 전략
 
-    private let webViewStrategy = WebViewStrategy() // webview 사용하는 pg
-    private let niceTransWebViewStrategy = NiceTransWebViewStrategy()
-    private let inicisTransWebViewStrategy = InicisTransWebViewStrategy()
+    private let webViewStrategy: WebViewStrategy // webview 사용하는 pg
+    private let niceTransWebViewStrategy: NiceTransWebViewStrategy
+    private let inicisTransWebViewStrategy: InicisTransWebViewStrategy
 
-    private let certificationWebViewStrategy = CertificationWebViewStrategy()
+    private let certificationWebViewStrategy: CertificationWebViewStrategy
 
     /**
      * PG 와 PayMethod 로 결제 타입하여 가져옴

--- a/Sources/iamport-ios/Classes/Domain/strategy/BaseStrategy.swift
+++ b/Sources/iamport-ios/Classes/Domain/strategy/BaseStrategy.swift
@@ -9,7 +9,11 @@ import RxSwift
 public class BaseStrategy: IStrategy {
     var disposeBag = DisposeBag()
     var request: IamportRequest?
-
+    let eventBus: EventBus
+    
+    init(eventBus: EventBus) {
+        self.eventBus = eventBus
+    }
     func clear() {
         request = nil
         disposeBag = DisposeBag()
@@ -38,14 +42,14 @@ public class BaseStrategy: IStrategy {
 
     func finish(_ response: IamportResponse?) {
         clear()
-        EventBus.shared.impResponseRelay.accept(response)
+        eventBus.impResponseRelay.accept(response)
     }
 
     func doWork(_ request: IamportRequest) {
         clear()
         self.request = request
 
-        EventBus.shared.clearBus.subscribe { [weak self] _ in
+        eventBus.clearBus.subscribe { [weak self] _ in
             self?.clear()
         }.disposed(by: disposeBag)
     }

--- a/Sources/iamport-ios/Classes/Domain/strategy/BaseWebViewStrategy.swift
+++ b/Sources/iamport-ios/Classes/Domain/strategy/BaseWebViewStrategy.swift
@@ -10,6 +10,11 @@ import WebKit
 public class BaseWebViewStrategy: IStrategy {
     var disposeBag = DisposeBag()
     var request: IamportRequest?
+    let eventBus: EventBus
+    
+    init(eventBus: EventBus) {
+        self.eventBus = eventBus
+    }
 
     func clear() {
         request = nil
@@ -39,7 +44,7 @@ public class BaseWebViewStrategy: IStrategy {
         clear()
         self.request = request
 
-        EventBus.shared.clearBus.subscribe { [weak self] _ in
+        eventBus.clearBus.subscribe { [weak self] _ in
             self?.clear() // 종료 없이 only clear
         }.disposed(by: disposeBag)
 

--- a/Sources/iamport-ios/Classes/Domain/strategy/JudgeStrategy.swift
+++ b/Sources/iamport-ios/Classes/Domain/strategy/JudgeStrategy.swift
@@ -12,9 +12,10 @@ public class JudgeStrategy: BaseStrategy {
     enum JudgeKind {
         case CHAI, WEB, CERT, ERROR
     }
-
     var ignoreNative = false
-
+    override init(eventBus: EventBus) {
+        super.init(eventBus: eventBus)
+    }
     func doWork(_ request: IamportRequest, ignoreNative: Bool) {
         self.ignoreNative = ignoreNative
         doWork(request)

--- a/Sources/iamport-ios/Classes/Presentation/IamportWebViewMode.swift
+++ b/Sources/iamport-ios/Classes/Presentation/IamportWebViewMode.swift
@@ -12,10 +12,17 @@ import WebKit
 
 class IamportWebViewMode: UIView, WKUIDelegate {
     var disposeBag = DisposeBag()
-    let viewModel = WebViewModel()
+    let viewModel: WebViewModel
 
     var webview: WKWebView?
     var request: IamportRequest?
+    init(eventBus: EventBus) {
+        self.viewModel = WebViewModel(eventBus: eventBus)
+        super.init(frame: .zero)
+    }
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     func start(webview: WKWebView) {
         debug_log("IamportWebViewMode :: start")
@@ -68,10 +75,9 @@ class IamportWebViewMode: UIView, WKUIDelegate {
 
     internal func subscribePayment() {
         debug_log("IamportWebViewMode :: subscribePayment")
-        let eventBus = EventBus.shared
 
         // 결제 데이터
-        eventBus.webViewPaymentBus.subscribe { [weak self] event in
+        viewModel.eventBus.webViewPaymentBus.subscribe { [weak self] event in
             guard let elem = event.element, let payment = elem else {
                 print("IamportWebViewMode :: Error not found PaymentEvent")
                 return
@@ -233,7 +239,7 @@ class IamportWebViewMode: UIView, WKUIDelegate {
         debug_dump(iamportResponse)
 
         close()
-        EventBus.shared.impResponseRelay.accept(iamportResponse)
+        viewModel.eventBus.impResponseRelay.accept(iamportResponse)
     }
 
     /**

--- a/Sources/iamport-ios/Classes/Presentation/MainViewModel.swift
+++ b/Sources/iamport-ios/Classes/Presentation/MainViewModel.swift
@@ -8,10 +8,14 @@ import RxSwift
 
 class MainViewModel {
     private var disposeBag = DisposeBag()
-    private let repository = StrategyRepository() // TODO: dependency inject
-
+    let eventBus: EventBus
+    private let repository: StrategyRepository // TODO: dependency inject
     func clear() {
         disposeBag = DisposeBag()
+    }
+    init() {
+        eventBus = EventBus()
+        repository = StrategyRepository(eventBus: eventBus)
     }
 
     func judgePayment(_ request: IamportRequest, ignoreNative: Bool = false) {
@@ -23,7 +27,7 @@ class MainViewModel {
                 if !valid {
                     IamportResponse.makeFail(request: request, msg: desc).do { it in
                         self?.clear()
-                        EventBus.shared.impResponseRelay.accept(it)
+                        self!.eventBus.impResponseRelay.accept(it)
                     }
                 }
             }
@@ -56,7 +60,7 @@ class MainViewModel {
                 }
             }
         case .WEB, .CERT:
-            EventBus.shared.paymentRelay.accept(judge.2) // 웹뷰 컨트롤러 열기
+            eventBus.paymentRelay.accept(judge.2) // 웹뷰 컨트롤러 열기
         case .ERROR:
             print("판단불가 \(judge)")
         }

--- a/Sources/iamport-ios/Classes/Presentation/WebViewController.swift
+++ b/Sources/iamport-ios/Classes/Presentation/WebViewController.swift
@@ -5,6 +5,7 @@ import UIKit
 import WebKit
 
 class WebViewController: UIViewController, WKUIDelegate, UINavigationBarDelegate {
+    let eventBus: EventBus
     // for communicate WebView
     enum JsInterface: String, CaseIterable {
         case RECEIVED = "received"
@@ -21,9 +22,18 @@ class WebViewController: UIViewController, WKUIDelegate, UINavigationBarDelegate
             return nil
         }
     }
+    init(eventBus: EventBus){
+        self.eventBus = eventBus
+        viewModel = WebViewModel(eventBus: self.eventBus)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     var disposeBag = DisposeBag()
-    let viewModel = WebViewModel()
+    let viewModel: WebViewModel
 
     var webView: WKWebView?
     var popupWebView: WKWebView? // window.open()으로 열리는 새창
@@ -42,6 +52,7 @@ class WebViewController: UIViewController, WKUIDelegate, UINavigationBarDelegate
         super.viewDidDisappear(animated)
         debug_log("viewDidDisappear")
         clearAll()
+        RxBus.shared.removeAllSubscription()
     }
 
     override func viewDidLoad() {
@@ -140,8 +151,6 @@ class WebViewController: UIViewController, WKUIDelegate, UINavigationBarDelegate
     }
 
     private func subscribePayment() {
-        let eventBus = EventBus.shared
-
         // 결제 데이터
         eventBus.webViewPaymentBus.subscribe { [weak self] event in
             guard let el = event.element, let request = el else {
@@ -277,7 +286,7 @@ class WebViewController: UIViewController, WKUIDelegate, UINavigationBarDelegate
 
         navigationController?.popViewController(animated: false)
         dismiss(animated: true) {
-            EventBus.shared.impResponseRelay.accept(iamportResponse)
+            self.eventBus.impResponseRelay.accept(iamportResponse)
         }
     }
 

--- a/Sources/iamport-ios/Classes/Presentation/WebViewModel.swift
+++ b/Sources/iamport-ios/Classes/Presentation/WebViewModel.swift
@@ -7,9 +7,14 @@ import RxBusForPort
 import RxSwift
 
 internal class WebViewModel {
-    let repository = StrategyRepository()
+    let eventBus: EventBus
+    let repository: StrategyRepository
     let delegate = IamportWKWebViewDelegate()
 
+    init(eventBus: EventBus) {
+        self.eventBus = eventBus
+        repository = StrategyRepository(eventBus: self.eventBus)
+    }
     /**
      * 뱅크페이 결과 처리
      */


### PR DESCRIPTION
고객사로 부터 인입된 다음 [이슈](https://portone-io.slack.com/archives/C066YFGP1GF/p1727849368670349)를 수정하기 위한 PR입니다.

### 배경
 iamport-ios에서는 static eventBus인 Rxbus.shared, EventBus.shared를 구독하여, 해당 eventbus들에 webViewUrl 변경 등의 이벤트가 발생 시 카드사 팝업 호출, 결제 완료 등 이벤트를 처리하고있습니다. 

### 원인
해당 [코드](https://github.com/iamport/iamport-ios/pull/46/files#diff-138d2c214eb20a6bc1932f9639b3a5de99ce41ceb9136c06ef225be61d71f5b9L143)에서 중복으로 구독이 일어나, 모든 이벤트를 재구독하고 있어 해당 이슈가 발생합니다.

### 해결
중복 구독이 일어나지 않도록 static객체인 EventBus.shared 대신, MainViewModel에 static이 아닌 eventBus를 정의하여, 해당 eventBus를 참조하도록 수정했습니다. 또한 Rxbus의 subscription도 결제 완료 혹은 결제창을 닫은 뒤에 초기화 하도록 removeall 함수를 추가하여 구독중인 이벤트들을 초기화 하도록 했습니다.

Rxbus 수정사항: https://github.com/portone-io/RxBus-Swift/pull/3